### PR TITLE
Fix: Eslint configuration/package script

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 node_modules/
+source/libraries/

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,9 @@
 module.exports = {
   "env": {
     "browser": true,
-    "es2021": true
+    "es2021": true,
+    "jquery": true,
+    "webextensions": true
   },
   "extends": "eslint:recommended",
   "overrides": [
@@ -21,6 +23,11 @@ module.exports = {
       "ecmaVersion": "latest",
       "sourceType": "module"
   },
+  "globals": {
+    "Coloris": "readonly"
+  },
   "rules": {
+    "no-case-declarations": "off",
+    "no-unused-vars": "off"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
     "eslint": "^8.55.0"
   },
   "scripts": {
-    "test": "npx eslint"
+    "test": "eslint ./"
   }
 }


### PR DESCRIPTION
This fixes the `test` package script and adjusts the eslint configuration to remove false positives so that it can be useful to find a few misplaced `=` operators!