### PR TITLE
Fix: Inconsistent feature loading in menu

### DIFF
--- a/source/meta/menu.js
+++ b/source/meta/menu.js
@@ -44,10 +44,10 @@
     const installedFeatures = await getJsonFile('!features');
     const features = {};
 
-    installedFeatures.forEach(async name => {
+    await Promise.all(installedFeatures.map(async name => {
       const featureData = await getJsonFile(name);
       if (featureData) features[name] = featureData;
-    });
+    }));
 
     return features;
   };


### PR DESCRIPTION
There's currently a race condition in the menu where features don't appear. This is due to `importFeatures` resolving before it finishes setting the `features` object keys, as there's no built-in way to await a `forEach` with an async callback. This uses `Promise.all` and `Array.map` to create the desired effect.

This does the same thing, but is slower:
```js
    for (const name of installedFeatures) {
      const featureData = await getJsonFile(name);
      if (featureData) features[name] = featureData;
    }
  ```