### PR TITLE
Implement MV3-safe injection

### DIFF
--- a/source/scripts/utility/injectableFunctions.js
+++ b/source/scripts/utility/injectableFunctions.js
@@ -1,0 +1,124 @@
+/**
+ * tumblr.js
+ */
+
+export async function apiFetch (resource, init = {}) {
+  init.headers ??= {};
+  init.headers['DBPlus'] = '1';
+
+  if (init.body !== undefined) {
+    const objects = [init.body];
+
+    while (objects.length !== 0) {
+      const currentObjects = objects.splice(0);
+
+      currentObjects.forEach(obj => {
+        Object.keys(obj).forEach(key => {
+          const snakeCaseKey = key
+            .replace(/^[A-Z]/, match => match.toLowerCase())
+            .replace(/[A-Z]/g, match => `_${match.toLowerCase()}`);
+
+          if (snakeCaseKey !== key) {
+            obj[snakeCaseKey] = obj[key];
+            delete obj[key];
+          }
+        });
+      });
+
+      objects.push(
+        ...currentObjects
+          .flatMap(Object.values)
+          .filter(value => value instanceof Object)
+      );
+    }
+  }
+
+  return window.tumblr.apiFetch(resource, init);
+}
+
+export async function navigate (path) {
+  window.tumblr.navigate(path);
+}
+
+/**
+ * reactProps.js
+ */
+
+export async function getTimelineObject (elem) {
+  const fiberKey = Object.keys(elem).find(key => key.startsWith('__reactFiber'));
+  let fiber = elem[fiberKey];
+
+  while (fiber !== null) {
+    const { timelineObject } = fiber.memoizedProps || {};
+    if (typeof timelineObject !== 'undefined') {
+      return timelineObject;
+    } else {
+      fiber = fiber.return;
+    }
+  }
+}
+
+export async function getNotificationObject (elem) {
+  const fiberKey = Object.keys(elem).find(key => key.startsWith('__reactFiber'));
+  let fiber = elem[fiberKey];
+
+  while (fiber !== null) {
+    const { notification } = fiber.memoizedProps || {};
+    if (typeof notification !== 'undefined') {
+      return notification;
+    } else {
+      fiber = fiber.return;
+    }
+  }
+}
+
+export async function getOtherBlog (elem) {
+  const fiberKey = Object.keys(elem).find(key => key.startsWith('__reactFiber'));
+  let fiber = elem[fiberKey];
+  let conversationWindowObject, headerImageFocused, backgroundColor, titleColor, linkColor;
+
+  while (fiber !== null) {
+    ({ conversationWindowObject } = fiber.memoizedProps || {});
+    if (typeof conversationWindowObject !== 'undefined') {
+      break;
+    } else {
+      fiber = fiber.return;
+    }
+  }
+
+  const { otherParticipantName, selectedBlogName } = conversationWindowObject;
+
+  await window.tumblr.apiFetch(`/v2/blog/${otherParticipantName}/info?fields[blogs]=theme`).then(response => {
+    ({ headerImageFocused, backgroundColor, titleColor, linkColor } = response.response.blog.theme);
+  });
+
+  return ({ headerImageFocused, backgroundColor, titleColor, linkColor, otherParticipantName, selectedBlogName });
+}
+
+export async function getPercentage (elem) {
+  const fiberKey = Object.keys(elem).find(key => key.startsWith('__reactFiber'));
+  let fiber = elem[fiberKey];
+
+  while (fiber !== null) {
+    const { percentage, answer } = fiber.memoizedProps || {};
+    if (typeof percentage !== 'undefined' && typeof answer !== 'undefined') {
+      return { percentage };
+    } else {
+      fiber = fiber.return;
+    }
+  }
+}
+
+export async function getNoteObject (elem) {
+  const fiberKey = Object.keys(elem).find(key => key.startsWith('__reactFiber'));
+  let fiber = elem[fiberKey];
+
+  while (fiber !== null) {
+    const { note } = fiber.memoizedProps || {};
+    if (typeof note !== 'undefined') {
+      return note;
+    } else {
+      fiber = fiber.return;
+    }
+  }
+}

--- a/source/scripts/utility/reactProps.js
+++ b/source/scripts/utility/reactProps.js
@@ -6,93 +6,13 @@ const conversationCache = new WeakMap();
 const percentageCache = new WeakMap();
 const noteCache = new WeakMap();
 
-const getTimelineObject = async () => {
-  const elem = document.currentScript.parentElement;
-  const fiberKey = Object.keys(elem).find(key => key.startsWith('__reactFiber'));
-  let fiber = elem[fiberKey];
-
-  while (fiber !== null) {
-    const { timelineObject } = fiber.memoizedProps || {};
-    if (typeof timelineObject !== 'undefined') {
-      return timelineObject;
-    } else {
-      fiber = fiber.return;
-    }
-  }
-};
-const getNotificationObject = async () => {
-  const elem = document.currentScript.parentElement;
-  const fiberKey = Object.keys(elem).find(key => key.startsWith('__reactFiber'));
-  let fiber = elem[fiberKey];
-
-  while (fiber !== null) {
-    const { notification } = fiber.memoizedProps || {};
-    if (typeof notification !== 'undefined') {
-      return notification;
-    } else {
-      fiber = fiber.return;
-    }
-  }
-};
-const getOtherBlog = async () => {
-  const elem = document.currentScript.parentElement;
-  const fiberKey = Object.keys(elem).find(key => key.startsWith('__reactFiber'));
-  let fiber = elem[fiberKey];
-  let conversationWindowObject, headerImageFocused, backgroundColor, titleColor, linkColor;
-
-  while (fiber !== null) {
-    ({ conversationWindowObject } = fiber.memoizedProps || {});
-    if (typeof conversationWindowObject !== 'undefined') {
-      break;
-    } else {
-      fiber = fiber.return;
-    }
-  }
-
-  const { otherParticipantName, selectedBlogName } = conversationWindowObject;
-
-  await window.tumblr.apiFetch(`/v2/blog/${otherParticipantName}/info?fields[blogs]=theme`).then(response => {
-    ({ headerImageFocused, backgroundColor, titleColor, linkColor } = response.response.blog.theme);
-  });
-
-  return ({ headerImageFocused, backgroundColor, titleColor, linkColor, otherParticipantName, selectedBlogName });
-};
-const getPercentage = async () => {
-  const elem = document.currentScript.parentElement;
-  const fiberKey = Object.keys(elem).find(key => key.startsWith('__reactFiber'));
-  let fiber = elem[fiberKey];
-
-  while (fiber !== null) {
-    const { percentage, answer } = fiber.memoizedProps || {};
-    if (typeof percentage !== 'undefined' && typeof answer !== 'undefined') {
-      return { percentage };
-    } else {
-      fiber = fiber.return;
-    }
-  }
-};
-const getNoteObject = async () => {
-  const elem = document.currentScript.parentElement;
-  const fiberKey = Object.keys(elem).find(key => key.startsWith('__reactFiber'));
-  let fiber = elem[fiberKey];
-
-  while (fiber !== null) {
-    const { note } = fiber.memoizedProps || {};
-    if (typeof note !== 'undefined') {
-      return note;
-    } else {
-      fiber = fiber.return;
-    }
-  }
-};
-
 /**
  * @param {Element} post - Post element to fetch property from
  * @returns {any} Fetched timelineObject property
  */
 export const timelineObject = async post => {
   if (!timelineObjectCache.has(post)) {
-    timelineObjectCache.set(post, inject(getTimelineObject, [], post));
+    timelineObjectCache.set(post, inject('getTimelineObject', [], post));
   }
 
   return timelineObjectCache.get(post);
@@ -104,7 +24,7 @@ export const timelineObject = async post => {
  */
 export const notificationObject = async notification => {
   if (!notificationCache.has(notification)) {
-    notificationCache.set(notification, inject(getNotificationObject, [], notification));
+    notificationCache.set(notification, inject('getNotificationObject', [], notification));
   }
 
   return notificationCache.get(notification);
@@ -112,7 +32,7 @@ export const notificationObject = async notification => {
 
 export const conversationInfo = async conversation => {
   if (!conversationCache.has(conversation)) {
-    conversationCache.set(conversation, inject(getOtherBlog, ['z'], conversation));
+    conversationCache.set(conversation, inject('getOtherBlog', [], conversation));
   }
 
   return conversationCache.get(conversation);
@@ -120,7 +40,7 @@ export const conversationInfo = async conversation => {
 
 export const percentageNumber = async answer => {
   if (!percentageCache.has(answer)) {
-    percentageCache.set(answer, inject(getPercentage, [], answer));
+    percentageCache.set(answer, inject('getPercentage', [], answer));
   }
 
   return percentageCache.get(answer);
@@ -128,7 +48,7 @@ export const percentageNumber = async answer => {
 
 export const noteObject = async note => {
   if (!noteCache.has(note)) {
-    noteCache.set(note, inject(getNoteObject, [], note));
+    noteCache.set(note, inject('getNoteObject', [], note));
   }
 
   return noteCache.get(note);

--- a/source/scripts/utility/tumblr.js
+++ b/source/scripts/utility/tumblr.js
@@ -43,45 +43,10 @@ export const replaceTranslate = (string = '', replaceValue = '') => translate(st
  * @returns {Promise<Response|Error>} Resolves or rejects with result of the API call
  */
 export const apiFetch = async (...args) => {
-  return inject(
-    async (resource, init = {}) => {
-      init.headers ??= {};
-      init.headers['DBPlus'] = '1';
-
-      if (init.body !== undefined) {
-        const objects = [init.body];
-
-        while (objects.length !== 0) {
-          const currentObjects = objects.splice(0);
-
-          currentObjects.forEach(obj => {
-            Object.keys(obj).forEach(key => {
-              const snakeCaseKey = key
-                .replace(/^[A-Z]/, match => match.toLowerCase())
-                .replace(/[A-Z]/g, match => `_${match.toLowerCase()}`);
-
-              if (snakeCaseKey !== key) {
-                obj[snakeCaseKey] = obj[key];
-                delete obj[key];
-              }
-            });
-          });
-
-          objects.push(
-            ...currentObjects
-              .flatMap(Object.values)
-              .filter(value => value instanceof Object)
-          );
-        }
-      }
-
-      return window.tumblr.apiFetch(resource, init);
-    },
-    args
-  );
+  return inject('apiFetch', args);
 };
 
 /**
  * @param {string} url - Relative URL to navigate to
  */
-export const navigate = async url => inject((path) => window.tumblr.navigate(path), [url]);
+export const navigate = async url => inject('navigate', [url]);


### PR DESCRIPTION
Manifest V3 disallows execution of script elements with arbitrary strings, which is the method currently used for `inject`. Or, apparently, it actually doesn't, considering that loading this extension into Firefox seems to work fine as-is. I'm not sure what the deal with that is. Anyway.

In case this either does wind up getting implemented by Firefox, or it currently is implemented but not in developer mode (yikes), or if you want the ability to port this extension to Chromium (which does enforce this rule), this demonstrates one of many ways to move the injected function bodies into a file somewhere and call them remotely by name rather than copying them by text into a script element. Based on https://github.com/AprilSylph/XKit-Rewritten/pull/1330.

Tested in Chromium, which also requires pasting `globalThis.browser = globalThis.chrome` in a bunch of places (which is stupid) and adding `"service_worker": "control/background.js"` to the `background` key of the extension manifest.