### PR TITLE
Fix: Tumblr Patio breaks horizontal header

### DIFF
--- a/source/scripts/horizontalNavigation.css
+++ b/source/scripts/horizontalNavigation.css
@@ -230,6 +230,9 @@
     align-items: center !important;
     font-size: 0px !important;
   }
+  [data-css~='navigation'] > [data-css~='patioFeedback'] {
+    display: none;
+  }
   [data-css~='container'][data-css~='mainContentIs4ColumnMasonry'] { margin: 0 auto !important; }
   @media (max-width: 1150px) {
     [data-css~='searchSidebarItem'] {


### PR DESCRIPTION
This fixes the horizontal header going invisible on the Tumblr Patio page.

It doesn't completely fix the layout (`mainContentWrapper` shouldn't have a top margin on Patio), but the DOM structure of the page doesn't change at that level when you switch to patio, so fixing it is probably not trivial and it at least doesn't break anything.